### PR TITLE
fix(audio-tool-bug): loading online non-mp3 file

### DIFF
--- a/libs/miroflow-tool/src/miroflow/tool/mcp_servers/audio_mcp_server.py
+++ b/libs/miroflow-tool/src/miroflow/tool/mcp_servers/audio_mcp_server.py
@@ -149,11 +149,6 @@ async def audio_transcription(audio_path_or_url: str) -> str:
 
                 # Check content type if available
                 content_type = response.headers.get("content-type", "").lower()
-                if content_type and not any(
-                    media_type in content_type
-                    for media_type in ["audio", "video", "application/octet-stream"]
-                ):
-                    raise Exception(f"Invalid content type '{content_type}'.")
 
                 # Get proper extension for the temporary file
                 file_extension = _get_audio_extension(audio_path_or_url, content_type)
@@ -229,11 +224,6 @@ async def audio_question_answering(audio_path_or_url: str, question: str) -> str
 
             # Check content type if available
             content_type = response.headers.get("content-type", "").lower()
-            if content_type and not any(
-                media_type in content_type
-                for media_type in ["audio", "video", "application/octet-stream"]
-            ):
-                return f"[ERROR]: Audio question answering failed: Invalid content type '{content_type}'. Expected audio file.\nNote: Files from sandbox are not available. You should use local path given in the instruction. \nURLs must include the proper scheme (e.g., 'https://') and be publicly accessible. The file should be in a common audio format such as MP3.\nNote: YouTube video URL is not supported."
 
             # Get proper extension for the temporary file
             file_extension = _get_audio_extension(audio_path_or_url, content_type)


### PR DESCRIPTION
remove content type validation for audio files in transcription and QA functions, which caused failing in loading online non-mp3 file

# Describe this PR

# Checklist for PR
## Must Do
- [x] Write a good PR title and description, i.e. `feat(agent): add pdf tool via mcp`, `perf: make llm client async` and `fix(utils): load custom config via importlib` etc. CI job `check-pr-title` enforces [Angular commit message format](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#commit-message-format) to PR title.
- [ ] Run `make precommit` locally. CI job `lint` enforce ruff default format/lint rules on all new codes.
- [ ] Run `make pytest`. Check test summary (located at `report.html`) and coverage report (located at `htmlcov/index.html`) on new codes.

## Nice To Have

- [ ] (Optional) Write/update tests under `/tests` for `feat` and `test` PR.
- [ ] (Optional) Write/update docs under `/docs` for `docs` and `ci` PR.


