### PR TITLE
fix(tool): inject openrouter key and base url into reasoning tool

### DIFF
--- a/libs/miroflow/src/miroflow/utils/tool_utils.py
+++ b/libs/miroflow/src/miroflow/utils/tool_utils.py
@@ -93,6 +93,8 @@ def create_mcp_server_parameters(
                     env={
                         "ANTHROPIC_API_KEY": cfg.env.anthropic_api_key,
                         "ANTHROPIC_BASE_URL": cfg.env.anthropic_base_url,
+                        "OPENROUTER_API_KEY": cfg.env.openrouter_api_key,
+                        "OPENROUTER_BASE_URL": cfg.env.openrouter_base_url,
                     },
                 ),
             }


### PR DESCRIPTION
# Describe this PR

The reasoning tool defined in `reasoning-mcp-server.py` appears to use OpenRouter. However, `tool_utils.py` does not pass the API key and base URL to `StdioServerParameters`.

# Checklist for PR
## Must Do
- [x] Write a good PR title and description, i.e. `feat(agent): add pdf tool via mcp`, `perf: make llm client async` and `fix(utils): load custom config via importlib` etc. CI job `check-pr-title` enforces [Angular commit message format](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#commit-message-format) to PR title.
- [ ] Run `make precommit` locally. CI job `lint` enforce ruff default format/lint rules on all new codes.
- [ ] Run `make pytest`. Check test summary (located at `report.html`) and coverage report (located at `htmlcov/index.html`) on new codes.

## Nice To Have

- [ ] (Optional) Write/update tests under `/tests` for `feat` and `test` PR.
- [ ] (Optional) Write/update docs under `/docs` for `docs` and `ci` PR.


