### PR TITLE
fix: TaskTracer validation error (Fixes #55)

### DIFF
--- a/utils/trace_single_task.py
+++ b/utils/trace_single_task.py
@@ -77,4 +77,4 @@ def main(
         cfg = hydra.compose(config_name=chosen_config_name, overrides=list(args))
         logger = bootstrap_logger(level=LOGGER_LEVEL)
         # Tracing functionality removed - miroflow-contrib deleted
-        asyncio.run(single_task(cfg, logger, task_id, task, task_file_name))
+        asyncio.run(single_task(cfg, logger, str(task_id), task, task_file_name))


### PR DESCRIPTION
# Describe this PR
This PR fixes a validation error that occurred when passing a numeric task_id to the trace command. Previously, Fire parsed --task_id=15 as an integer, which was then propagated to TaskTracer as both task_id and task_name, causing Pydantic to raise a string type validation error. The fix is to cast task_id to a string when calling single_task explicitly.

# Checklist for PR
## Must Do
- [ ] Write a good PR title and description, i.e. `feat(agent): add pdf tool via mcp`, `perf: make llm client async` and `fix(utils): load custom config via importlib` etc. CI job `check-pr-title` enforces [Angular commit message format](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#commit-message-format) to PR title.
- [ ] Run `make precommit` locally. CI job `lint` enforce ruff default format/lint rules on all new codes.
- [ ] Run `make pytest`. Check test summary (located at `report.html`) and coverage report (located at `htmlcov/index.html`) on new codes.

## Nice To Have

- [ ] (Optional) Write/update tests under `/tests` for `feat` and `test` PR.
- [ ] (Optional) Write/update docs under `/docs` for `docs` and `ci` PR.


