### PR TITLE
fix(llm_client): catch context limit error when using mirothinker as main model

### DIFF
--- a/src/llm/providers/claude_openrouter_client.py
+++ b/src/llm/providers/claude_openrouter_client.py
@@ -191,6 +191,8 @@ class ClaudeOpenRouterClient(LLMProviderClientBase):
                 or "exceeds the maximum length" in error_str
                 or "exceeds the maximum allowed length" in error_str
                 or "Input tokens exceed the configured limit" in error_str
+                or "Requested token count exceeds the model's maximum context length" in error_str
+                or "BadRequestError" in error_str and "context length" in error_str
             ):
                 logger.debug(f"OpenRouter LLM Context limit exceeded: {error_str}")
                 raise ContextLimitError(f"Context limit exceeded: {error_str}")

--- a/src/llm/providers/mirothinker_sglang_client.py
+++ b/src/llm/providers/mirothinker_sglang_client.py
@@ -159,6 +159,8 @@ class MiroThinkerSGLangClient(LLMProviderClientBase):
                 or "exceeds the maximum length" in error_str
                 or "exceeds the maximum allowed length" in error_str
                 or "Input tokens exceed the configured limit" in error_str
+                or "Requested token count exceeds the model's maximum context length" in error_str
+                or "BadRequestError" in error_str and "context length" in error_str
             ):
                 logger.debug(f"MiroThinker LLM Context limit exceeded: {error_str}")
                 raise ContextLimitError(f"Context limit exceeded: {error_str}")


### PR DESCRIPTION
# Describe this PR
 Modify the mirothinker and claude client to catch message indicating context limit error.

# Checklist for PR
## Must Do
- [ ] Write a good PR title and description, i.e. `feat(agent): add pdf tool via mcp`, `perf: make llm client async` and `fix(utils): load custom config via importlib` etc. CI job `check-pr-title` enforces [Angular commit message format](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#commit-message-format) to PR title.
- [ ] Run `make precommit` locally. CI job `lint` enforce ruff default format/lint rules on all new codes.
- [ ] Run `make pytest`. Check test summary (located at `report.html`) and coverage report (located at `htmlcov/index.html`) on new codes.

## Nice To Have

- [ ] (Optional) Write/update tests under `/tests` for `feat` and `test` PR.
- [ ] (Optional) Write/update docs under `/docs` for `docs` and `ci` PR.


