### PR TITLE
feat(hints, summary, docs): Refactor O3 parameters to generic names and restructure GAIA validation docs

### DIFF
--- a/config/agent_finsearchcomp.yaml
+++ b/config/agent_finsearchcomp.yaml
@@ -27,11 +27,13 @@ main_agent:
   max_tool_calls_per_turn: 10  # Maximum number of tool calls per turn
   
   input_process:
-    o3_hint: true
+    hint_generation: true
+    hint_llm_base_url: "${oc.env:HINT_LLM_BASE_URL,https://api.openai.com/v1}"
   output_process:
-    o3_final_answer: true
+    final_answer_extraction: true
+    final_answer_llm_base_url: "${oc.env:FINAL_ANSWER_LLM_BASE_URL,https://api.openai.com/v1}"
 
-  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for o3 hints and final answer extraction
+  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for hint generation and final answer extraction
   add_message_id: true
   keep_tool_result: -1
   chinese_context: "${oc.env:CHINESE_CONTEXT,false}"

--- a/config/agent_gaia-test.yaml
+++ b/config/agent_gaia-test.yaml
@@ -29,11 +29,13 @@ main_agent:
   max_tool_calls_per_turn: 10  # Maximum number of tool calls per turn
   
   input_process:
-    o3_hint: true
+    hint_generation: true
+    hint_llm_base_url: "${oc.env:HINT_LLM_BASE_URL,https://api.openai.com/v1}"
   output_process:
-    o3_final_answer: true
+    final_answer_extraction: true
+    final_answer_llm_base_url: "${oc.env:FINAL_ANSWER_LLM_BASE_URL,https://api.openai.com/v1}"
 
-  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for o3 hints and final answer extraction
+  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for hint generation and final answer extraction
   add_message_id: true
   keep_tool_result: -1
   chinese_context: "${oc.env:CHINESE_CONTEXT,false}"

--- a/config/agent_gaia-validation-text-only.yaml
+++ b/config/agent_gaia-validation-text-only.yaml
@@ -29,11 +29,13 @@ main_agent:
   max_tool_calls_per_turn: 10  # Maximum number of tool calls per turn
   
   input_process:
-    o3_hint: true
+    hint_generation: true
+    hint_llm_base_url: "${oc.env:HINT_LLM_BASE_URL,https://api.openai.com/v1}"
   output_process:
-    o3_final_answer: true
+    final_answer_extraction: true
+    final_answer_llm_base_url: "${oc.env:FINAL_ANSWER_LLM_BASE_URL,https://api.openai.com/v1}"
 
-  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for o3 hints and final answer extraction
+  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for hint generation and final answer extraction
   add_message_id: true
   keep_tool_result: -1
   chinese_context: "${oc.env:CHINESE_CONTEXT,false}"

--- a/config/agent_gaia-validation_claude37sonnet.yaml
+++ b/config/agent_gaia-validation_claude37sonnet.yaml
@@ -29,11 +29,13 @@ main_agent:
   max_tool_calls_per_turn: 10  # Maximum number of tool calls per turn
   
   input_process:
-    o3_hint: true
+    hint_generation: true
+    hint_llm_base_url: "${oc.env:HINT_LLM_BASE_URL,https://api.openai.com/v1}"
   output_process:
-    o3_final_answer: true
+    final_answer_extraction: true
+    final_answer_llm_base_url: "${oc.env:FINAL_ANSWER_LLM_BASE_URL,https://api.openai.com/v1}"
 
-  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for o3 hints and final answer extraction
+  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for hint generation and final answer extraction
   add_message_id: true
   keep_tool_result: -1
   chinese_context: "${oc.env:CHINESE_CONTEXT,false}"

--- a/config/agent_gaia-validation_mirothinker.yaml
+++ b/config/agent_gaia-validation_mirothinker.yaml
@@ -5,33 +5,33 @@ defaults:
 
 
 main_agent:
-  prompt_class: MainAgentPromptBoxedAnswer
+  prompt_class: MainAgentPrompt_GAIA
   llm: 
-    provider_class: "ClaudeOpenRouterClient"
-    model_name: "anthropic/claude-3.7-sonnet"
+    provider_class: "MiroThinkerSGLangClient"
+    model_name: "MODEL_NAME"
     async_client: true
     temperature: 0.3
-    top_p: 0.95
+    top_p: 1.0
     min_p: 0.0
     top_k: -1
-    max_tokens: 32000
-    openrouter_api_key: "${oc.env:OPENROUTER_API_KEY,???}"
-    openrouter_base_url: "${oc.env:OPENROUTER_BASE_URL,https://openrouter.ai/api/v1}"
-    openrouter_provider: "anthropic"
-    disable_cache_control: false
+    max_tokens: 4096
+    oai_mirothinker_api_key: "${oc.env:OAI_MIROTHINKER_API_KEY,dummy_key}"
+    oai_mirothinker_base_url: "${oc.env:OAI_MIROTHINKER_BASE_URL,http://localhost:61005/v1}"
     keep_tool_result: -1
     oai_tool_thinking: false
   
-  tool_config: []
+  tool_config:
+    - tool-reasoning
 
-  max_turns: -1  # Maximum number of turns for main agent execution
+  max_turns: 50  # Maximum number of turns for main agent execution
   max_tool_calls_per_turn: 10  # Maximum number of tool calls per turn
   
   input_process:
     hint_generation: false
     hint_llm_base_url: "${oc.env:HINT_LLM_BASE_URL,https://api.openai.com/v1}"
+    
   output_process:
-    final_answer_extraction: false
+    final_answer_extraction: true
     final_answer_llm_base_url: "${oc.env:FINAL_ANSWER_LLM_BASE_URL,https://api.openai.com/v1}"
 
   openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for hint generation and final answer extraction
@@ -44,29 +44,30 @@ sub_agents:
   agent-worker:
     prompt_class: SubAgentWorkerPrompt
     llm: 
-      provider_class: "ClaudeOpenRouterClient"
-      model_name: "anthropic/claude-3.7-sonnet"
+      provider_class: "MiroThinkerSGLangClient"
+      model_name: "MODEL_NAME"
       async_client: true
       temperature: 0.3
-      top_p: 0.95
+      top_p: 1.0
       min_p: 0.0
       top_k: -1
-      max_tokens: 32000
-      openrouter_api_key: "${oc.env:OPENROUTER_API_KEY,???}"
-      openrouter_base_url: "${oc.env:OPENROUTER_BASE_URL,https://openrouter.ai/api/v1}"
-      openrouter_provider: "anthropic"
-      disable_cache_control: false
+      max_tokens: 4096
+      oai_mirothinker_api_key: "${oc.env:OAI_MIROTHINKER_API_KEY,dummy_key}"
+      oai_mirothinker_base_url: "${oc.env:OAI_MIROTHINKER_BASE_URL,http://localhost:61005/v1}"
       keep_tool_result: -1
       oai_tool_thinking: false
     
     tool_config:
+      - tool-searching
+      - tool-image-video
       - tool-reading
+      - tool-code
+      - tool-audio
 
-    max_turns: -1  # Maximum number of turns for main agent execution
+    max_turns: 50  # Maximum number of turns for main agent execution
     max_tool_calls_per_turn: 10  # Maximum number of tool calls per turn
 
 
 # Can define some top-level or default parameters here
 output_dir: logs/
 data_dir: "${oc.env:DATA_DIR,data}"  # Points to where data is stored
-

--- a/config/agent_mirothinker.yaml
+++ b/config/agent_mirothinker.yaml
@@ -26,11 +26,13 @@ main_agent:
   max_tool_calls_per_turn: 10  # Maximum number of tool calls per turn
   
   input_process:
-    o3_hint: false
+    hint_generation: false
+    hint_llm_base_url: "${oc.env:HINT_LLM_BASE_URL,https://api.openai.com/v1}"
   output_process:
-    o3_final_answer: false
+    final_answer_extraction: false
+    final_answer_llm_base_url: "${oc.env:FINAL_ANSWER_LLM_BASE_URL,https://api.openai.com/v1}"
 
-  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for o3 hints and final answer extraction
+  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for hint generation and final answer extraction
   add_message_id: true
   keep_tool_result: -1
   chinese_context: "${oc.env:CHINESE_CONTEXT,false}"

--- a/config/agent_xbench-ds.yaml
+++ b/config/agent_xbench-ds.yaml
@@ -29,11 +29,13 @@ main_agent:
   max_tool_calls_per_turn: 10  # Maximum number of tool calls per turn
   
   input_process:
-    o3_hint: true
+    hint_generation: true
+    hint_llm_base_url: "${oc.env:HINT_LLM_BASE_URL,https://api.openai.com/v1}"
   output_process:
-    o3_final_answer: true
+    final_answer_extraction: true
+    final_answer_llm_base_url: "${oc.env:FINAL_ANSWER_LLM_BASE_URL,https://api.openai.com/v1}"
 
-  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for o3 hints and final answer extraction
+  openai_api_key: "${oc.env:OPENAI_API_KEY,???}" # used for hint generation and final answer extraction
   add_message_id: true
   keep_tool_result: -1
   chinese_context: "true"

--- a/docs/mkdocs/docs/all_about_agents.md
+++ b/docs/mkdocs/docs/all_about_agents.md
@@ -103,6 +103,9 @@ Welcome to our comprehensive resource collection for AI agents. This page curate
 - **Terminal-Bench**: the benchmark for testing AI agents in real terminal environments 
     - [:material-github: GitHub](https://github.com/laude-institute/terminal-bench)
 
+- **Gaia2 and ARE**: Empowering the Community to Evaluate Agents
+    - [:material-file-document: Blog Post](https://huggingface.co/blog/gaia2)
+
 ---
 
 !!! info "Documentation Info"

--- a/docs/mkdocs/docs/finsearchcomp.md
+++ b/docs/mkdocs/docs/finsearchcomp.md
@@ -63,7 +63,7 @@ E2B_API_KEY="xxx"
 OAI_MIROTHINKER_API_KEY="xxx"
 OAI_MIROTHINKER_BASE_URL="http://localhost:61005/v1"
 
-# Used for o3 hints and final answer extraction
+# Used for hint generation and final answer extraction
 OPENAI_API_KEY="xxx"
 OPENAI_BASE_URL="https://api.openai.com/v1"
 

--- a/docs/mkdocs/docs/futurex.md
+++ b/docs/mkdocs/docs/futurex.md
@@ -64,7 +64,7 @@ ANTHROPIC_API_KEY="xxx"
 # Used for Gemini vision
 GEMINI_API_KEY="xxx"
 
-# Use for llm judge, reasoning, o3 hints, etc.
+# Use for llm judge, reasoning, hint generation, etc.
 OPENAI_API_KEY="xxx"
 OPENAI_BASE_URL="https://api.openai.com/v1"
 ```

--- a/docs/mkdocs/docs/gaia_test.md
+++ b/docs/mkdocs/docs/gaia_test.md
@@ -41,7 +41,7 @@ OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"
 ANTHROPIC_API_KEY="your-anthropic-api-key"
 GEMINI_API_KEY="your-gemini-api-key"
 
-# LLM judge, reasoning, and O3 hints
+# LLM judge, reasoning, and hint generation
 OPENAI_API_KEY="your-openai-api-key"
 OPENAI_BASE_URL="https://api.openai.com/v1"
 ```

--- a/docs/mkdocs/docs/gaia_validation_claude37sonnet.md
+++ b/docs/mkdocs/docs/gaia_validation_claude37sonnet.md
@@ -1,0 +1,93 @@
+# GAIA Validation - Claude 3.7 Sonnet
+
+MiroFlow demonstrates state-of-the-art performance on the GAIA validation benchmark using Claude 3.7 Sonnet models, showcasing exceptional capabilities in complex reasoning tasks that require multi-step problem solving, information synthesis, and tool usage.
+
+!!! info "Prerequisites"
+    Before proceeding, please review the [GAIA Validation Prerequisites](gaia_validation_prerequisites.md) document, which covers common setup requirements, dataset preparation, and API key configuration.
+
+---
+
+## Performance Comparison
+
+!!! success "State-of-the-Art Performance with Claude 3.7 Sonnet"
+    MiroFlow achieves **state-of-the-art (SOTA) performance** among open-source agent frameworks on the GAIA validation set using Claude 3.7 Sonnet.
+
+<div align="center" markdown="1">
+  ![GAIA Validation Performance](../assets/gaia_score.png){ width="100%" }
+</div>
+
+!!! abstract "Key Performance Metrics"
+    - **Pass@3**: **81.8%**
+    - **Majority Vote**: **82.4%**
+    - **Pass@1 (best@3)**: **74.5%**
+    - **Pass@1 (avg@3)**: **72.2%**
+
+!!! info "Reproducibility Guarantee"
+    Unlike other frameworks with unclear evaluation methods, MiroFlow's results are **fully reproducible**. Note that Hugging Face access was disabled during inference to prevent direct answer retrieval.
+
+---
+
+## Running the Evaluation
+
+### Step 1: Dataset Preparation
+
+Follow the [dataset preparation instructions](gaia_validation_prerequisites.md#dataset-preparation) in the prerequisites document.
+
+### Step 2: API Keys Configuration
+
+Configure the following API keys in your `.env` file:
+
+```env title="Claude 3.7 Sonnet .env Configuration"
+# Primary LLM provider (Claude-3.7-Sonnet via OpenRouter)
+OPENROUTER_API_KEY="your-openrouter-api-key"
+OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"
+
+# Search and web scraping capabilities
+SERPER_API_KEY="your-serper-api-key"
+JINA_API_KEY="your-jina-api-key"
+
+# Code execution environment
+E2B_API_KEY="your-e2b-api-key"
+
+# Vision understanding capabilities
+ANTHROPIC_API_KEY="your-anthropic-api-key"
+GEMINI_API_KEY="your-gemini-api-key"
+
+# LLM judge, reasoning, and hint generation
+OPENAI_API_KEY="your-openai-api-key"
+OPENAI_BASE_URL="https://api.openai.com/v1"
+```
+
+### Step 3: Run the Evaluation
+
+Execute the evaluation using the Claude 3.7 Sonnet configuration:
+
+```bash title="Run GAIA Validation with Claude 3.7 Sonnet"
+uv run main.py common-benchmark \
+  --config_file_name=agent_gaia-validation_claude37sonnet \
+  output_dir="logs/gaia-validation-claude37sonnet/$(date +"%Y%m%d_%H%M")"
+```
+
+### Step 4: Monitor Progress
+
+Follow the [progress monitoring instructions](gaia_validation_prerequisites.md#progress-monitoring-and-resume) in the prerequisites document.
+
+---
+
+## Execution Traces
+
+!!! info "Complete Execution Traces"
+    We have released our complete execution traces for the `gaia-validation` dataset using Claude 3.7 Sonnet on Hugging Face. This comprehensive collection includes a full run of 165 tasks with an overall accuracy of 73.94% and detailed reasoning traces.
+
+You can download them using the following command:
+
+```bash title="Download Execution Traces"
+wget https://huggingface.co/datasets/miromind-ai/MiroFlow-Benchmarks/resolve/main/gaia_validation_miroflow_trace_public_20250825.zip
+unzip gaia_validation_miroflow_trace_public_20250825.zip
+# Unzip passcode: pf4*
+```
+
+---
+
+!!! info "Documentation Info"
+    **Last Updated:** October 2025 · **Doc Contributor:** Team @ MiroMind AI

--- a/docs/mkdocs/docs/gaia_validation_mirothinker.md
+++ b/docs/mkdocs/docs/gaia_validation_mirothinker.md
@@ -1,0 +1,73 @@
+# GAIA Validation - MiroThinker
+
+MiroFlow demonstrates state-of-the-art performance on the GAIA validation benchmark using MiroThinker models, showcasing exceptional capabilities in complex reasoning tasks that require multi-step problem solving, information synthesis, and tool usage.
+
+!!! info "Prerequisites"
+    Before proceeding, please review the [GAIA Validation Prerequisites](gaia_validation_prerequisites.md) document, which covers common setup requirements, dataset preparation, and API key configuration.
+
+---
+
+## Running the Evaluation
+
+### Step 1: Dataset Preparation
+
+Follow the [dataset preparation instructions](gaia_validation_prerequisites.md#dataset-preparation) in the prerequisites document.
+
+### Step 2: API Keys Configuration
+
+Configure the following API keys in your `.env` file:
+
+```env title="MiroThinker .env Configuration"
+# MiroThinker model access
+OAI_MIROTHINKER_API_KEY="your-mirothinker-api-key"
+OAI_MIROTHINKER_BASE_URL="http://localhost:61005/v1"
+
+# Search and web scraping capabilities
+SERPER_API_KEY="your-serper-api-key"
+JINA_API_KEY="your-jina-api-key"
+
+# Code execution environment
+E2B_API_KEY="your-e2b-api-key"
+
+# Vision understanding capabilities
+ANTHROPIC_API_KEY="your-anthropic-api-key"
+GEMINI_API_KEY="your-gemini-api-key"
+
+# LLM judge, reasoning, and hint generation
+OPENAI_API_KEY="your-openai-api-key"
+OPENAI_BASE_URL="https://api.openai.com/v1"
+
+# Hint Generation and final answer with MiroThinker model
+HINT_LLM_BASE_URL="http://localhost:61005/v1"
+FINAL_ANSWER_LLM_BASE_URL="http://localhost:61005/v1"
+
+```
+
+### Step 3: Run the Evaluation
+
+Execute the evaluation using the MiroThinker configuration:
+
+```bash title="Run GAIA Validation with MiroThinker"
+uv run main.py common-benchmark \
+  --config_file_name=agent_gaia-validation_mirothinker \
+  output_dir="logs/gaia-validation-mirothinker/$(date +"%Y%m%d_%H%M")"
+```
+
+### Step 4: Monitor Progress
+
+Follow the [progress monitoring instructions](gaia_validation_prerequisites.md#progress-monitoring-and-resume) in the prerequisites document.
+
+## Multiple Runs
+
+Due to performance variance in MiroThinker models, it's recommended to run multiple evaluations for more reliable results.
+
+```bash title="Run Multiple MiroThinker Evaluations"
+bash ./scripts/run_evaluate_multiple_runs_mirothinker_gaia-validation.sh
+```
+
+This script runs 3 evaluations in parallel and calculates average scores. You can modify `NUM_RUNS` in the script to change the number of runs.
+
+---
+
+!!! info "Documentation Info"
+    **Last Updated:** October 2025 · **Doc Contributor:** Team @ MiroMind AI

--- a/docs/mkdocs/docs/gaia_validation_prerequisites.md
+++ b/docs/mkdocs/docs/gaia_validation_prerequisites.md
@@ -1,0 +1,88 @@
+# GAIA Validation Prerequisites
+
+This document covers the common setup requirements and prerequisites for running GAIA validation benchmarks with MiroFlow, regardless of the specific model configuration used.
+
+## About the GAIA Dataset
+
+!!! info "What is GAIA?"
+    GAIA (General AI Assistant) is a comprehensive benchmark designed to evaluate AI agents' ability to perform complex reasoning tasks that require multiple skills including web browsing, file manipulation, data analysis, and multi-step problem solving.
+
+More details: [GAIA: a benchmark for General AI Assistants](https://arxiv.org/abs/2311.12983)
+
+---
+
+## Dataset Preparation
+
+### Step 1: Prepare the GAIA Validation Dataset
+
+Choose one of the following methods to obtain the GAIA validation dataset:
+
+**Method 1: Direct Download (Recommended)**
+
+!!! tip "No Authentication Required"
+    This method does not require HuggingFace tokens or access permissions.
+
+```bash title="Manual Dataset Download"
+cd data
+wget https://huggingface.co/datasets/miromind-ai/MiroFlow-Benchmarks/resolve/main/gaia-val.zip
+unzip gaia-val.zip
+# Unzip passcode: pf4*
+```
+
+**Method 2: Using the prepare-benchmark command**
+
+!!! warning "Prerequisites Required"
+    This method requires HuggingFace dataset access and token configuration.
+
+First, you need to request access and configure your environment:
+
+1. **Request Dataset Access**: Visit [https://huggingface.co/datasets/gaia-benchmark/GAIA](https://huggingface.co/datasets/gaia-benchmark/GAIA) and request access
+2. **Configure Environment**: 
+   ```bash
+   cp .env.template .env
+   ```
+   Edit the `.env` file:
+   ```env
+   HF_TOKEN="your-actual-huggingface-token-here"
+   DATA_DIR="data/"
+   ```
+
+!!! tip "Getting Your Hugging Face Token"
+    1. Go to [https://huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)
+    2. Create a new token with at least "Read" permissions
+    3. Add your token to the `.env` file
+
+Then download the dataset:
+
+```bash title="Download via Script"
+uv run main.py prepare-benchmark get gaia-val
+```
+
+---
+
+## Progress Monitoring and Resume
+
+### Progress Tracking
+
+You can monitor the evaluation progress in real-time:
+
+```bash title="Check Progress"
+uv run utils/progress_check/check_gaia_progress.py $PATH_TO_LOG
+```
+
+Replace `$PATH_TO_LOG` with your actual output directory path.
+
+### Resume Capability
+
+If the evaluation is interrupted, you can resume from where it left off by specifying the same output directory:
+
+```bash title="Resume Interrupted Evaluation"
+uv run main.py common-benchmark \
+  --config_file_name=YOUR_CONFIG_FILE \
+  output_dir="logs/gaia-validation/20250922_1430"
+```
+
+---
+
+!!! info "Documentation Info"
+    **Last Updated:** October 2025 · **Doc Contributor:** Team @ MiroMind AI

--- a/docs/mkdocs/docs/gaia_validation_text_only.md
+++ b/docs/mkdocs/docs/gaia_validation_text_only.md
@@ -51,7 +51,7 @@ OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"
 ANTHROPIC_API_KEY="your-anthropic-api-key"
 GEMINI_API_KEY="your-gemini-api-key"
 
-# LLM judge, reasoning, and O3 hints
+# LLM judge, reasoning, and hint generation
 OPENAI_API_KEY="your-openai-api-key"
 OPENAI_BASE_URL="https://api.openai.com/v1"
 ```

--- a/docs/mkdocs/docs/openai-gpt.md
+++ b/docs/mkdocs/docs/openai-gpt.md
@@ -1,6 +1,6 @@
 # OpenAI GPT Models
 
-OpenAI's latest models including GPT-4o and O3 reasoning models with strong coding, vision, and reasoning capabilities.
+OpenAI's latest models including GPT-4o and advanced reasoning models with strong coding, vision, and reasoning capabilities.
 
 ## Client Used
 
@@ -19,7 +19,7 @@ export OPENAI_BASE_URL="https://api.openai.com/v1"  # optional
 main_agent:
   llm: 
     provider_class: "GPTOpenAIClient"
-    model_name: "gpt-4o"  # or o3, etc.
+    model_name: "gpt-4o"  # or gpt-4o-mini, etc.
     openai_api_key: "${oc.env:OPENAI_API_KEY,???}"
     openai_base_url: "${oc.env:OPENAI_BASE_URL,https://api.openai.com/v1}"
 ```

--- a/docs/mkdocs/docs/prerequisite.md
+++ b/docs/mkdocs/docs/prerequisite.md
@@ -1,13 +1,13 @@
-# GAIA Validation
+# GAIA Validation Prerequisites
 
-MiroFlow demonstrates state-of-the-art performance on the GAIA validation benchmark, showcasing exceptional capabilities in complex reasoning tasks that require multi-step problem solving, information synthesis, and tool usage.
-
-More details: [GAIA: a benchmark for General AI Assistants](https://arxiv.org/abs/2311.12983)
+This document covers the common setup requirements and prerequisites for running GAIA validation benchmarks with MiroFlow, regardless of the specific model configuration used.
 
 ## About the GAIA Dataset
 
 !!! info "What is GAIA?"
     GAIA (General AI Assistant) is a comprehensive benchmark designed to evaluate AI agents' ability to perform complex reasoning tasks that require multiple skills including web browsing, file manipulation, data analysis, and multi-step problem solving.
+
+More details: [GAIA: a benchmark for General AI Assistants](https://arxiv.org/abs/2311.12983)
 
 ---
 
@@ -31,10 +31,7 @@ More details: [GAIA: a benchmark for General AI Assistants](https://arxiv.org/ab
 
 ---
 
-## Setup and Evaluation Guide
-
-!!! note "Complete Reproduction Instructions"
-    This section provides comprehensive step-by-step instructions to reproduce our GAIA validation benchmark results. All results are fully reproducible using our open-source framework.
+## Dataset Preparation
 
 ### Step 1: Prepare the GAIA Validation Dataset
 
@@ -81,12 +78,15 @@ Then download the dataset:
 uv run main.py prepare-benchmark get gaia-val
 ```
 
-### Step 2: Configure API Keys
+---
 
-!!! warning "Required API Configuration"
-    Set up the required API keys for model access and tool functionality. Update the `.env` file to include the following keys:
+## Common API Keys Configuration
 
-```env title=".env Configuration"
+### Required API Keys
+
+The following API keys are required for all GAIA validation runs, regardless of the model configuration:
+
+```env title="Common .env Configuration"
 # Search and web scraping capabilities
 SERPER_API_KEY="your-serper-api-key"
 JINA_API_KEY="your-jina-api-key"
@@ -94,37 +94,31 @@ JINA_API_KEY="your-jina-api-key"
 # Code execution environment
 E2B_API_KEY="your-e2b-api-key"
 
-# Primary LLM provider (Claude-3.7-Sonnet via OpenRouter)
-OPENROUTER_API_KEY="your-openrouter-api-key"
-OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"
-
 # Vision understanding capabilities
 ANTHROPIC_API_KEY="your-anthropic-api-key"
 GEMINI_API_KEY="your-gemini-api-key"
 
-# LLM judge, reasoning, and O3 hints
+# LLM judge, reasoning, and hint generation
 OPENAI_API_KEY="your-openai-api-key"
 OPENAI_BASE_URL="https://api.openai.com/v1"
 ```
 
-!!! tip "Why OpenRouter?"
-    We use Claude-3.7-Sonnet through the OpenRouter backend as the primary LLM provider because OpenRouter offers better response rates and improved reliability compared to direct API access.
+### API Key Descriptions
 
-### Step 3: Run the Evaluation
+- **SERPER_API_KEY**: Required for web search functionality
+- **JINA_API_KEY**: Required for web scraping and content extraction
+- **E2B_API_KEY**: Required for secure code execution environment
+- **ANTHROPIC_API_KEY**: Required for vision understanding capabilities
+- **GEMINI_API_KEY**: Required for additional vision processing
+- **OPENAI_API_KEY**: Required for hint generation and final answer extraction
 
-Execute the evaluation using the following command:
+---
 
-```bash title="Run GAIA Validation"
-uv run main.py common-benchmark \
-  --config_file_name=agent_gaia-validation \
-  output_dir="logs/gaia-validation/$(date +"%Y%m%d_%H%M")"
-```
+## Progress Monitoring and Resume
 
+### Progress Tracking
 
-### Step 4: Monitor Progress and Resume
-
-!!! tip "Progress Tracking"
-    You can monitor the evaluation progress in real-time:
+You can monitor the evaluation progress in real-time:
 
 ```bash title="Check Progress"
 uv run utils/progress_check/check_gaia_progress.py $PATH_TO_LOG
@@ -132,12 +126,13 @@ uv run utils/progress_check/check_gaia_progress.py $PATH_TO_LOG
 
 Replace `$PATH_TO_LOG` with your actual output directory path.
 
-!!! note "Resume Capability"
-    If the evaluation is interrupted, you can resume from where it left off by specifying the same output directory:
+### Resume Capability
+
+If the evaluation is interrupted, you can resume from where it left off by specifying the same output directory:
 
 ```bash title="Resume Interrupted Evaluation"
 uv run main.py common-benchmark \
-  --config_file_name=agent_gaia-validation \
+  --config_file_name=YOUR_CONFIG_FILE \
   output_dir="logs/gaia-validation/20250922_1430"
 ```
 
@@ -146,7 +141,7 @@ uv run main.py common-benchmark \
 ## Execution Traces
 
 !!! info "Complete Execution Traces"
-    We have released our complete execution traces for the `gaia-validation` dataset on Hugging Face. This comprehensive collection includes a full run of 165 tasks with an overall accuracy of 73.94%.
+    We have released our complete execution traces for the `gaia-validation` dataset on Hugging Face. This comprehensive collection includes a full run of 165 tasks with detailed reasoning traces.
 
 You can download them using the following command:
 

--- a/docs/mkdocs/docs/xbench_ds.md
+++ b/docs/mkdocs/docs/xbench_ds.md
@@ -43,7 +43,7 @@ OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"
 ANTHROPIC_API_KEY="your-anthropic-api-key"
 GEMINI_API_KEY="your-gemini-api-key"
 
-# LLM as judge, reasoning, and O3 hints
+# LLM as judge, reasoning, and hint generation
 OPENAI_API_KEY="your-openai-api-key"
 OPENAI_BASE_URL="https://api.openai.com/v1"
 ```

--- a/docs/mkdocs/docs/yaml_config.md
+++ b/docs/mkdocs/docs/yaml_config.md
@@ -111,9 +111,9 @@ main_agent:
     - tool-reasoning
   
   input_process:
-    o3_hint: true              # Use O3 for task hints
+    hint_generation: true      # Use LLM for task hint generation
   output_process:
-    o3_final_answer: true      # Use O3 for answer extraction
+    final_answer_extraction: true  # Use LLM for answer extraction
 
 sub_agents:
   agent-worker:

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -41,7 +41,7 @@ nav:
     - News & Updates: index.md
     - License: license.md
 
-  - Overview:
+  - Quick Start:
     - Quickstart: quickstart.md
     - Core Concepts: core_concepts.md
     - YAML Configuration: yaml_config.md
@@ -49,7 +49,10 @@ nav:
   - Evaluation:
     - Overview: evaluation_overview.md
     - Benchmarks: 
-      - GAIA-Validation: gaia_validation.md
+      - GAIA-Validation:
+        - Prerequisites: gaia_validation_prerequisites.md
+        - Claude-3.7-Sonnet: gaia_validation_claude37sonnet.md
+        - MiroThinker: gaia_validation_mirothinker.md
       - GAIA-Validation-Text-Only: gaia_validation_text_only.md
       - GAIA-Test: gaia_test.md
       - FutureX: futurex.md

--- a/scripts/run_evaluate_multiple_runs_mirothinker_gaia-validation.sh
+++ b/scripts/run_evaluate_multiple_runs_mirothinker_gaia-validation.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2025 MiromindAI
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Configuration parameters
+NUM_RUNS=3
+AGENT_SET="agent_gaia-validation_mirothinker"
+MAX_CONCURRENT=15
+
+# Set results directory with timestamp
+TIMESTAMP=$(date +%Y%m%d_%H%M)
+RESULTS_DIR=${RESULTS_DIR:-"logs/${BENCHMARK_NAME}/${AGENT_SET}_${TIMESTAMP}"}
+
+echo "Starting $NUM_RUNS runs of the evaluation..."
+echo "Results will be saved in: $RESULTS_DIR"
+
+# Create results directory
+mkdir -p "$RESULTS_DIR"
+
+for i in $(seq 1 $NUM_RUNS); do
+    echo "=========================================="
+    echo "Launching experiment $i/$NUM_RUNS"
+    echo "=========================================="
+    
+    RUN_ID="run_$i"
+    
+    (
+        uv run main.py common-benchmark \
+            --config_file_name=$AGENT_SET \
+            benchmark.execution.max_concurrent=$MAX_CONCURRENT \
+            output_dir="$RESULTS_DIR/$RUN_ID" \
+            hydra.run.dir=${RESULTS_DIR}/$RUN_ID \
+            > "$RESULTS_DIR/${RUN_ID}_output.log" 2>&1
+        
+        if [ $? -eq 0 ]; then
+            echo "Run $i completed successfully"
+            RESULT_FILE=$(find "${RESULTS_DIR}/$RUN_ID" -name "*accuracy.txt" 2>/dev/null | head -1)
+            if [ -f "$RESULT_FILE" ]; then
+                echo "Results saved to $RESULT_FILE"
+            else
+                echo "Warning: Result file not found for run $i"
+            fi
+        else
+            echo "Run $i failed!"
+        fi
+    ) &
+    
+    sleep 2
+done
+
+echo "All $NUM_RUNS runs have been launched in parallel"
+echo "Waiting for all runs to complete..."
+
+wait
+
+echo "=========================================="
+echo "All $NUM_RUNS runs completed!"
+echo "=========================================="
+
+echo "Calculating average scores..."
+uv run main.py avg-score "$RESULTS_DIR"
+
+echo "=========================================="
+echo "Multiple runs evaluation completed!"
+echo "Check results in: $RESULTS_DIR"
+echo "Check individual run logs: $RESULTS_DIR/run_*_output.log"
+echo "==========================================" 
+

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -23,9 +23,9 @@ from src.tool.manager import ToolManager
 from src.utils.io_utils import OutputFormatter, process_input
 from src.utils.tool_utils import expose_sub_agents_as_tools
 from src.utils.summary_utils import (
-    o3_extract_hints,
-    o3_extract_gaia_final_answer,
-    o3_extract_browsecomp_zh_final_answer,
+    extract_hints,
+    extract_gaia_final_answer,
+    extract_browsecomp_zh_final_answer,
 )
 
 LOGGER_LEVEL = os.getenv("LOGGER_LEVEL", "INFO")
@@ -726,32 +726,33 @@ Your objective is maximum completeness, transparency, and detailed documentation
             initial_user_content[0]["text"] + task_guidence
         )
 
-        o3_notes = ""  # Initialize o3_notes
-        if self.cfg.main_agent.input_process.o3_hint:
-            # Execute O3 hints extraction
+        hint_notes = ""  # Initialize hint_notes
+        if self.cfg.main_agent.input_process.hint_generation:
+            # Execute hint generation
             try:
-                o3_hints = await o3_extract_hints(
+                hint_content = await extract_hints(
                     task_description,
                     self.cfg.main_agent.openai_api_key,
                     self.chinese_context,
                     self.add_message_id,
+                    self.cfg.main_agent.input_process.get('hint_llm_base_url', 'https://api.openai.com/v1'),
                 )
-                o3_notes = (
+                hint_notes = (
                     "\n\nBefore you begin, please review the following preliminary notes highlighting subtle or easily misunderstood points in the question, which might help you avoid common pitfalls during your analysis (for reference only; these may not be exhaustive):\n\n"
-                    + o3_hints
+                    + hint_content
                 )
 
                 # Update initial user content
                 original_text = initial_user_content[0]["text"]
-                initial_user_content[0]["text"] = original_text + o3_notes
+                initial_user_content[0]["text"] = original_text + hint_notes
             except Exception as e:
-                logger.error(f"O3 hints extraction failed after retries: {str(e)}")
+                logger.error(f"Hint generation failed after retries: {str(e)}")
                 self.task_log.log_step(
-                    step_name="o3_hint",
-                    message=f"[ERROR] O3 hint generation failed: {str(e)}",
+                    step_name="hint_generation",
+                    message=f"[ERROR] Hint generation failed: {str(e)}",
                     status="failed",
                 )
-                o3_notes = ""  # Continue execution but without O3 hints
+                hint_notes = ""  # Continue execution but without hints
 
         logger.info("Initial user input content: %s", initial_user_content)
         message_history = [{"role": "user", "content": initial_user_content}]
@@ -993,71 +994,73 @@ Your objective is maximum completeness, transparency, and detailed documentation
                 "final_answer_content", f"Final answer content: {final_answer_text}"
             )
 
-            # Use O3 model to extract final answer
-            o3_extracted_answer = ""
-            if self.cfg.main_agent.output_process.o3_final_answer:
-                # Execute O3 final answer extraction
+            # Use LLM to extract final answer
+            extracted_answer = ""
+            if self.cfg.main_agent.output_process.final_answer_extraction:
+                # Execute final answer extraction
                 try:
                     # For browsecomp-zh, we use another Chinese prompt to extract the final answer
                     if "browsecomp-zh" in self.cfg.benchmark.name:
-                        o3_extracted_answer = (
-                            await o3_extract_browsecomp_zh_final_answer(
+                        extracted_answer = (
+                            await extract_browsecomp_zh_final_answer(
                                 task_description,
                                 final_answer_text,
                                 self.cfg.main_agent.openai_api_key,
+                                self.cfg.main_agent.output_process.get('final_answer_llm_base_url', 'https://api.openai.com/v1'),
                             )
                         )
 
-                        # Disguise O3 extracted answer as assistant returned result and add to message history
-                        assistant_o3_message = {
+                        # Disguise LLM extracted answer as assistant returned result and add to message history
+                        assistant_extracted_message = {
                             "role": "assistant",
                             "content": [
                                 {
                                     "type": "text",
-                                    "text": f"O3 extracted final answer:\n{o3_extracted_answer}",
+                                    "text": f"LLM extracted final answer:\n{extracted_answer}",
                                 }
                             ],
                         }
-                        message_history.append(assistant_o3_message)
+                        message_history.append(assistant_extracted_message)
 
-                        # o3 answer as final result
-                        final_answer_text = o3_extracted_answer
+                        # LLM answer as final result
+                        final_answer_text = extracted_answer
                     else:
-                        o3_extracted_answer = await o3_extract_gaia_final_answer(
+                        extracted_answer = await extract_gaia_final_answer(
                             task_description,
                             final_answer_text,
                             self.cfg.main_agent.openai_api_key,
                             self.chinese_context,
+                            self.cfg.main_agent.output_process.get('final_answer_llm_base_url', 'https://api.openai.com/v1'),
                         )
 
-                        # Disguise O3 extracted answer as assistant returned result and add to message history
-                        assistant_o3_message = {
+                        # Disguise LLM extracted answer as assistant returned result and add to message history
+                        assistant_extracted_message = {
                             "role": "assistant",
                             "content": [
                                 {
                                     "type": "text",
-                                    "text": f"O3 extracted final answer:\n{o3_extracted_answer}",
+                                    "text": f"LLM extracted final answer:\n{extracted_answer}",
                                 }
                             ],
                         }
-                        message_history.append(assistant_o3_message)
+                        message_history.append(assistant_extracted_message)
 
-                        # Concatenate original summary and o3 answer as final result
-                        final_answer_text = f"{final_answer_text}\n\nO3 Extracted Answer:\n{o3_extracted_answer}"
+                        # Concatenate original summary and LLM answer as final result
+                        final_answer_text = f"{final_answer_text}\n\nLLM Extracted Answer:\n{extracted_answer}"
 
                 except Exception as e:
                     logger.error(
-                        f"O3 final answer extraction failed after retries: {str(e)}"
+                        f"Final answer extraction failed after retries: {str(e)}"
                     )
                     self.task_log.log_step(
-                        step_name="o3_final_answer",
-                        message=f"[ERROR] O3 final answer extraction failed: {str(e)}",
+                        step_name="final_answer_extraction",
+                        message=f"[ERROR] Final answer extraction failed: {str(e)}",
                         status="failed",
                     )
                     # Continue using original final_answer_text
 
             else:
-                # to process when o3_final_answer is false
+                # to process when final_answer_extraction is false
                 # leave it here to be more clear
                 final_answer_text = final_answer_text
 
@@ -1069,7 +1072,7 @@ Your objective is maximum completeness, transparency, and detailed documentation
 
         logger.debug(f"LLM Final Answer: {final_answer_text}")
 
-        # Save final message history (including O3 processing results)
+        # Save final message history (including LLM processing results)
         self.task_log.main_agent_message_history = {
             "system_prompt": system_prompt,
             "message_history": message_history,

--- a/utils/eval_utils.py
+++ b/utils/eval_utils.py
@@ -154,7 +154,7 @@ async def verify_answer_llm_xbench(
     openai_client: AsyncOpenAI, question: str, target: str, predicted_answer: str
 ) -> str:
     """
-    Use XBench-style LLM judge (o3) to verify if the predicted answer is correct.
+    Use XBench-style LLM judge to verify if the predicted answer is correct.
     Uses structured output format similar to verify_answer_llm_hle.
 
     Args:

--- a/utils/util_llm_parallel_thinking.py
+++ b/utils/util_llm_parallel_thinking.py
@@ -64,7 +64,7 @@ def process_message_history(main_agent_message_history: Dict[str, Any]) -> str:
         # Process the last message content
         final_content = message_history[-1]["content"][0]["text"]
         final_content = final_content.replace(
-            "O3 extracted final answer:", "## Final Answer Reasoning\n"
+            "LLM extracted final answer:", "## Final Answer Reasoning\n"
         )
 
         # Concatenate the two parts

--- a/utils/util_llm_simple_voting.py
+++ b/utils/util_llm_simple_voting.py
@@ -56,7 +56,7 @@ def process_message_history(main_agent_message_history: Dict[str, Any]) -> str:
         # Process the last message content
         final_content = message_history[-1]["content"][0]["text"]
         final_content = final_content.replace(
-            "O3 extracted final answer:", "## Final Answer Reasoning\n"
+            "LLM extracted final answer:", "## Final Answer Reasoning\n"
         )
 
         # Concatenate the two parts


### PR DESCRIPTION
## Summary
- Renamed O3-specific parameters to generic model-agnostic names across all configs and code
- Extracted common GAIA validation content into `gaia_validation_prerequisites.md`
- Renamed config files for consistency: `agent_gaia-validation_mirothinker.yaml`, `agent_gaia-validation_claude37sonnet.yaml`
- Added multiple runs section for MiroThinker with performance variance explanation
- Moved API keys configuration to model-specific documentation

## Changes
- **Parameters**: `o3_hint` → `hint_generation`, `o3_final_answer` → `final_answer_extraction`, etc.
- **Code**: Updated function names and references in `orchestrator.py` and `summary_utils.py`
- **Configs**: Updated all YAML files with new parameter names
- **Docs**: Restructured GAIA validation documentation with model-specific files
- **Scripts**: Updated script references to use new config file names

